### PR TITLE
Expose port 2368  in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY ./entrypoint.sh /
 
 RUN chmod +x /entrypoint.sh
 
+EXPOSE 2368
+
 #Run Init System
 ENTRYPOINT [ "tini" ]
 


### PR DESCRIPTION
Exposing the port in the Dockerfile removes the explicit need to use the `-p` or `--expose` flag when using `docker run`.
