### PR TITLE
Updating to 0.11.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,22 @@ MAINTAINER ZZROT LLC <docker@zzrot.com>
 #ENV VARIABLES
 ENV GHOST_SOURCE /usr/src/app
 ENV GHOST_CONTENT /var/lib/ghost
-ENV GHOST_VERSION 0.11.4
+ENV GHOST_VERSION 0.11.7
+ENV GHOST_URL https://github.com/TryGhost/Ghost/releases/download/${GHOST_VERSION}/Ghost-${GHOST_VERSION}.zip
 
 #Change WORKDIR to ghost directory
 WORKDIR $GHOST_SOURCE
 
 RUN apk --no-cache add tar tini \
-    && apk --no-cache add --virtual devs gcc make python wget unzip ca-certificates \
-    && wget -O ghost.zip https://github.com/TryGhost/Ghost/releases/download/${GHOST_VERSION}/Ghost-${GHOST_VERSION}.zip \
-	# && wget -O ghost.zip "https://ghost.org/archives/ghost-${GHOST_VERSION}.zip" \
-	&& unzip ghost.zip \
+    && apk --no-cache add --virtual devs gcc make python libarchive-tools curl ca-certificates \
+    && curl -sL ${GHOST_URL} | bsdtar -xf- -C ${GHOST_SOURCE} \
 	&& npm install --production \
-	&& rm ghost.zip \
 	&& apk del devs \
 	&& npm cache clean \
 	&& rm -rf /tmp/npm*
 
 #Copy over our configuration filename
-COPY ./config.js $GHOST_SOURCE
+COPY ./config.js ${GHOST_SOURCE}
 
 #Copy over, and grant executable permission to the startup script
 COPY ./entrypoint.sh /


### PR DESCRIPTION
Updating image to 0.11.7 and changing the download/uncompress approach
to curl bsdtar instead of wget unzip mv. Now we save the stream
output already uncompressed and do not have to move or remove zip files.

fixes #16 